### PR TITLE
Add userstr type

### DIFF
--- a/draconic/helpers.py
+++ b/draconic/helpers.py
@@ -1,10 +1,10 @@
 import ast
 import operator as op
-from collections import UserList
 
 from .exceptions import *
+from .types import *
 
-__all__ = ("DraconicConfig", "OperatorMixin", "approx_len_of", "safe_dict", "safe_list", "safe_set")
+__all__ = ("DraconicConfig", "OperatorMixin")
 
 # ===== config =====
 DISALLOW_PREFIXES = ['_', 'func_']
@@ -53,6 +53,7 @@ class DraconicConfig:
         self._list = safe_list(self)
         self._dict = safe_dict(self)
         self._set = safe_set(self)
+        self._str = safe_str(self)
 
         # default names
         if default_names is None:
@@ -71,11 +72,15 @@ class DraconicConfig:
     def set(self):
         return self._set
 
+    @property
+    def str(self):
+        return self._str
+
     def _default_names(self):
         return {
             "True": True, "False": False, "None": None,
             # functions
-            "bool": bool, "int": int, "float": float, "str": str, "tuple": tuple,
+            "bool": bool, "int": int, "float": float, "str": self.str, "tuple": tuple,
             "dict": self.dict, "list": self.list, "set": self.set
         }
 
@@ -181,163 +186,3 @@ class OperatorMixin:
             _raise_in_context(NumberTooHigh, "This number is too large")
         if isinstance(b, int) and (b < self._config.min_int or b > self._config.max_int):
             _raise_in_context(NumberTooHigh, "This number is too large")
-
-
-def approx_len_of(obj, visited=None):
-    """Gets the approximate size of an object (including recursive objects)."""
-    if isinstance(obj, str):
-        return len(obj)
-
-    if hasattr(obj, "__approx_len__"):
-        return obj.__approx_len__
-
-    if visited is None:
-        visited = [obj]
-
-    size = op.length_hint(obj)
-
-    if isinstance(obj, dict):
-        obj = obj.items()
-
-    try:
-        for child in iter(obj):
-            if child in visited:
-                continue
-            size += approx_len_of(child, visited)
-            visited.append(child)
-    except TypeError:  # object is not iterable
-        pass
-
-    try:
-        setattr(obj, "__approx_len__", size)
-    except AttributeError:
-        pass
-
-    return size
-
-
-# ===== compound types =====
-# each function is a function that returns a class based on Draconic config
-# ... look, it works
-
-def safe_list(config):
-    class SafeList(UserList):  # extends UserList so that [x] * y returns a SafeList, not a list
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.__approx_len__ = approx_len_of(self)
-
-        def append(self, obj):
-            if approx_len_of(self) + 1 > config.max_const_len:
-                _raise_in_context(IterableTooLong, "This list is too long")
-            super().append(obj)
-            self.__approx_len__ += 1
-
-        def extend(self, iterable):
-            other_len = approx_len_of(iterable)
-            if approx_len_of(self) + other_len > config.max_const_len:
-                _raise_in_context(IterableTooLong, "This list is too long")
-            super().extend(iterable)
-            self.__approx_len__ += other_len
-
-        def pop(self, i=-1):
-            retval = super().pop(i)
-            self.__approx_len__ -= 1
-            return retval
-
-        def remove(self, item):
-            super().remove(item)
-            self.__approx_len__ -= 1
-
-        def clear(self):
-            super().clear()
-            self.__approx_len__ = 0
-
-        def __mul__(self, n):
-            # to prevent the recalculation of the length on list mult we manually set a new instance's
-            # data and approx len (JIRA-54)
-            new = SafeList()
-            new.data = self.data * n
-            new.__approx_len__ = self.__approx_len__ * n
-            return new
-
-    return SafeList
-
-
-def safe_set(config):
-    class SafeSet(set):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.__approx_len__ = approx_len_of(self)
-
-        def update(self, *s):
-            other_lens = sum(approx_len_of(other) for other in s)
-            if approx_len_of(self) + other_lens > config.max_const_len:
-                _raise_in_context(IterableTooLong, "This set is too large")
-            super().update(*s)
-            self.__approx_len__ += other_lens
-
-        def add(self, element):
-            if approx_len_of(self) + 1 > config.max_const_len:
-                _raise_in_context(IterableTooLong, "This set is too large")
-            super().add(element)
-            self.__approx_len__ += 1
-
-        def union(self, *s):
-            if approx_len_of(self) + sum(approx_len_of(other) for other in s) > config.max_const_len:
-                _raise_in_context(IterableTooLong, "This set is too large")
-            return SafeSet(super().union(*s))
-
-        def pop(self):
-            retval = super().pop()
-            self.__approx_len__ -= 1
-            return retval
-
-        def remove(self, element):
-            super().remove(element)
-            self.__approx_len__ -= 1
-
-        def discard(self, element):
-            super().discard(element)
-            self.__approx_len__ -= 1
-
-        def clear(self):
-            super().clear()
-            self.__approx_len__ = 0
-
-    return SafeSet
-
-
-def safe_dict(config):
-    class SafeDict(dict):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.__approx_len__ = approx_len_of(self)
-
-        def update(self, other_dict=None, **kvs):
-            if other_dict is None:
-                other_dict = {}
-
-            other_lens = approx_len_of(other_dict) + approx_len_of(kvs)
-            if approx_len_of(self) + other_lens > config.max_const_len:
-                _raise_in_context(IterableTooLong, "This dict is too large")
-
-            super().update(other_dict, **kvs)
-            self.__approx_len__ += other_lens
-
-        def __setitem__(self, key, value):
-            other_len = approx_len_of(value)
-            if approx_len_of(self) + other_len > config.max_const_len:
-                _raise_in_context(IterableTooLong, "This dict is too large")
-            self.__approx_len__ += other_len
-            return super().__setitem__(key, value)
-
-        def pop(self, k):
-            retval = super().pop(k)
-            self.__approx_len__ -= 1
-            return retval
-
-        def __delitem__(self, key):
-            super().__delitem__(key)
-            self.__approx_len__ -= 1
-
-    return SafeDict

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -126,6 +126,8 @@ class SimpleInterpreter(OperatorMixin):
         if hasattr(node.value, '__len__') and len(node.value) > self._config.max_const_len:
             raise IterableTooLong(
                 f"Literal in statement is too long ({len(node.value)} > {self._config.max_const_len})", node)
+        if isinstance(node.value, bytes):
+            raise FeatureNotAvailable("Creation of bytes literals is not allowed", node)
         return node.value
 
     def _eval_unaryop(self, node):

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -239,8 +239,7 @@ class SimpleInterpreter(OperatorMixin):
 
     def _eval_formattedvalue(self, node):
         if node.format_spec:
-            fmt = "{:" + self._eval(node.format_spec) + "}"
-            return fmt.format(self._eval(node.value))  # todo use custom formatter
+            return self._str(format(self._eval(node.value), str(self._eval(node.format_spec))))
         return self._eval(node.value)
 
 

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -2,6 +2,7 @@ import ast
 
 from .exceptions import *
 from .helpers import DraconicConfig, OperatorMixin
+from .string import check_format_spec
 
 __all__ = ("SimpleInterpreter", "DraconicInterpreter")
 
@@ -241,7 +242,9 @@ class SimpleInterpreter(OperatorMixin):
 
     def _eval_formattedvalue(self, node):
         if node.format_spec:
-            return self._str(format(self._eval(node.value), str(self._eval(node.format_spec))))
+            format_spec = str(self._eval(node.format_spec))
+            check_format_spec(self._config, format_spec)
+            return self._str(format(self._eval(node.value), format_spec))
         return self._eval(node.value)
 
 

--- a/draconic/string.py
+++ b/draconic/string.py
@@ -1,6 +1,10 @@
 """String utilities for the userstring type."""
 import re
 
+__all__ = (
+    'FORMAT_SPEC_RE', 'JoinProxy', 'TranslateTableProxy'
+)
+
 # ==== format spec ====
 # https://docs.python.org/3/library/string.html#format-specification-mini-language
 _FILL = r"."
@@ -18,3 +22,39 @@ FORMAT_SPEC_RE = re.compile(rf"((?P<fill>{_FILL})?(?P<align>{_ALIGN}))?"
                             rf"(?P<grouping_option>{_GROUPING_OPTION})?"
                             rf"(?P<precision>\.{_PRECISION})?"
                             rf"(?P<type>{_TYPE})?")
+
+
+# ==== helpers ====
+class JoinProxy:
+    """
+    A helper to return the right types for str.join().
+    If the sequence would return a userstring, returns it as a base str instead.
+    """
+
+    def __init__(self, str_type, seq):
+        self._str_type = str_type
+        self.seq = seq
+
+    def __iter__(self):
+        for item in self.seq:
+            if isinstance(item, self._str_type):
+                yield str(item)
+            else:
+                yield item
+
+
+class TranslateTableProxy:
+    """
+    A helper to return the right types for str.translate().
+    If the table would return a userstring, returns it as a base str instead.
+    """
+
+    def __init__(self, str_type, table):
+        self._str_type = str_type
+        self.table = table
+
+    def __getitem__(self, item):
+        out = self.table[item]
+        if isinstance(out, self._str_type):  # translate() expects strictly a str type
+            return str(out)
+        return out

--- a/draconic/string.py
+++ b/draconic/string.py
@@ -1,6 +1,8 @@
 """String utilities for the userstring type."""
 import re
 
+from .exceptions import IterableTooLong, _raise_in_context
+
 __all__ = (
     'FORMAT_SPEC_RE', 'PRINTF_TEMPLATE_RE', 'JoinProxy', 'TranslateTableProxy'
 )
@@ -15,28 +17,46 @@ _WIDTH = r"\d+"
 _GROUPING_OPTION = r"[_,]"
 _PRECISION = r"\d+"
 _TYPE = r"[bcdeEfFgGnosxX%]"
-FORMAT_SPEC_RE = re.compile(rf"((?P<fill>{_FILL})?(?P<align>{_ALIGN}))?"
+FORMAT_SPEC_RE = re.compile(rf"(?:(?P<fill>{_FILL})?(?P<align>{_ALIGN}))?"
                             rf"(?P<sign>{_SIGN})?"
                             rf"(?P<alt_form>#)?"
                             rf"(?P<zero_pad>0)?"
                             rf"(?P<width>{_WIDTH})?"
                             rf"(?P<grouping_option>{_GROUPING_OPTION})?"
-                            rf"(?P<precision>\.{_PRECISION})?"
+                            rf"(?:\.(?P<precision>{_PRECISION}))?"
                             rf"(?P<type>{_TYPE})?")
+
+
+def check_format_spec(config, format_spec):
+    # validate that the format string is safe
+    match = FORMAT_SPEC_RE.match(format_spec)
+    if not match:
+        raise ValueError("Invalid format specifier")
+
+    precision_len = 0
+    w = match.group('width')
+    p = match.group('precision')
+    if w:
+        precision_len += int(w)
+    if p:
+        precision_len += int(p)
+    if precision_len > config.max_const_len:
+        _raise_in_context(IterableTooLong, "This str is too large")
+
 
 # printf-style
 # https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
-_PF_MAPPING_KEY = r"\([^)]*\)"  # any sequence of non-")"
+_PF_MAPPING_KEY = r"[^)]*"  # any sequence of non-")"
 _PF_CONVERSION_FLAGS = r"[#0\- +]"
 _PF_WIDTH = r"\*|\d+"
-_PF_PRECISION = r"(?:\*|\d+)"
+_PF_PRECISION = r"\*|\d+"
 _PF_LENGTH_MODIFIER = r"[hlL]"
 _PF_TYPE = r"[diouxXeEfFgGcrsa%]"
 PRINTF_TEMPLATE_RE = re.compile(rf"%"
-                                rf"(?P<mapping_key>{_PF_MAPPING_KEY})?"
+                                rf"(?:\((?P<mapping_key>{_PF_MAPPING_KEY})\))?"
                                 rf"(?P<conversion_flags>{_PF_CONVERSION_FLAGS})*"
                                 rf"(?P<width>{_PF_WIDTH})?"
-                                rf"(?P<precision>\.{_PF_PRECISION})?"
+                                rf"(?:\.(?P<precision>{_PF_PRECISION}))?"
                                 rf"(?P<length_modifier>{_PF_LENGTH_MODIFIER})?"
                                 rf"(?P<type>{_PF_TYPE})")
 

--- a/draconic/string.py
+++ b/draconic/string.py
@@ -1,0 +1,20 @@
+"""String utilities for the userstring type."""
+import re
+
+# ==== format spec ====
+# https://docs.python.org/3/library/string.html#format-specification-mini-language
+_FILL = r"."
+_ALIGN = r"[<>=^]"
+_SIGN = r"[+\- ]"
+_WIDTH = r"\d+"
+_GROUPING_OPTION = r"[_,]"
+_PRECISION = r"\d+"
+_TYPE = r"[bcdeEfFgGnosxX%]"
+FORMAT_SPEC_RE = re.compile(rf"((?P<fill>{_FILL})?(?P<align>{_ALIGN}))?"
+                            rf"(?P<sign>{_SIGN})?"
+                            rf"(?P<alt_form>#)?"
+                            rf"(?P<zero_pad>0)?"
+                            rf"(?P<width>{_WIDTH})?"
+                            rf"(?P<grouping_option>{_GROUPING_OPTION})?"
+                            rf"(?P<precision>\.{_PRECISION})?"
+                            rf"(?P<type>{_TYPE})?")

--- a/draconic/string.py
+++ b/draconic/string.py
@@ -2,10 +2,11 @@
 import re
 
 __all__ = (
-    'FORMAT_SPEC_RE', 'JoinProxy', 'TranslateTableProxy'
+    'FORMAT_SPEC_RE', 'PRINTF_TEMPLATE_RE', 'JoinProxy', 'TranslateTableProxy'
 )
 
 # ==== format spec ====
+# .format()-style
 # https://docs.python.org/3/library/string.html#format-specification-mini-language
 _FILL = r"."
 _ALIGN = r"[<>=^]"
@@ -22,6 +23,22 @@ FORMAT_SPEC_RE = re.compile(rf"((?P<fill>{_FILL})?(?P<align>{_ALIGN}))?"
                             rf"(?P<grouping_option>{_GROUPING_OPTION})?"
                             rf"(?P<precision>\.{_PRECISION})?"
                             rf"(?P<type>{_TYPE})?")
+
+# printf-style
+# https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
+_PF_MAPPING_KEY = r"\([^)]*\)"  # any sequence of non-")"
+_PF_CONVERSION_FLAGS = r"[#0\- +]"
+_PF_WIDTH = r"\*|\d+"
+_PF_PRECISION = r"(?:\*|\d+)"
+_PF_LENGTH_MODIFIER = r"[hlL]"
+_PF_TYPE = r"[diouxXeEfFgGcrsa%]"
+PRINTF_TEMPLATE_RE = re.compile(rf"%"
+                                rf"(?P<mapping_key>{_PF_MAPPING_KEY})?"
+                                rf"(?P<conversion_flags>{_PF_CONVERSION_FLAGS})*"
+                                rf"(?P<width>{_PF_WIDTH})?"
+                                rf"(?P<precision>\.{_PF_PRECISION})?"
+                                rf"(?P<length_modifier>{_PF_LENGTH_MODIFIER})?"
+                                rf"(?P<type>{_PF_TYPE})")
 
 
 # ==== helpers ====

--- a/draconic/types.py
+++ b/draconic/types.py
@@ -1,0 +1,235 @@
+import operator as op
+from collections import UserList, UserString
+
+from .exceptions import *
+
+__all__ = (
+    'safe_list', 'safe_dict', 'safe_set', 'safe_str', 'approx_len_of'
+)
+
+
+# ---- size helper ----
+def approx_len_of(obj, visited=None):
+    """Gets the approximate size of an object (including recursive objects)."""
+    if isinstance(obj, (str, bytes, UserString)):
+        return len(obj)
+
+    if hasattr(obj, "__approx_len__"):
+        return obj.__approx_len__
+
+    if visited is None:
+        visited = [obj]
+
+    size = op.length_hint(obj)
+
+    if isinstance(obj, dict):
+        obj = obj.items()
+
+    try:
+        for child in iter(obj):
+            if child in visited:
+                continue
+            size += approx_len_of(child, visited)
+            visited.append(child)
+    except TypeError:  # object is not iterable
+        pass
+
+    try:
+        setattr(obj, "__approx_len__", size)
+    except AttributeError:
+        pass
+
+    return size
+
+
+# ---- types ----
+# each function is a function that returns a class based on Draconic config
+# ... look, it works
+def safe_list(config):
+    class SafeList(UserList):  # extends UserList so that [x] * y returns a SafeList, not a list
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.__approx_len__ = approx_len_of(self)
+
+        def append(self, obj):
+            if approx_len_of(self) + 1 > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This list is too long")
+            super().append(obj)
+            self.__approx_len__ += 1
+
+        def extend(self, iterable):
+            other_len = approx_len_of(iterable)
+            if approx_len_of(self) + other_len > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This list is too long")
+            super().extend(iterable)
+            self.__approx_len__ += other_len
+
+        def pop(self, i=-1):
+            retval = super().pop(i)
+            self.__approx_len__ -= 1
+            return retval
+
+        def remove(self, item):
+            super().remove(item)
+            self.__approx_len__ -= 1
+
+        def clear(self):
+            super().clear()
+            self.__approx_len__ = 0
+
+        def __mul__(self, n):
+            # to prevent the recalculation of the length on list mult we manually set a new instance's
+            # data and approx len (JIRA-54)
+            new = SafeList()
+            new.data = self.data * n
+            new.__approx_len__ = self.__approx_len__ * n
+            return new
+
+    return SafeList
+
+
+def safe_set(config):
+    class SafeSet(set):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.__approx_len__ = approx_len_of(self)
+
+        def update(self, *s):
+            other_lens = sum(approx_len_of(other) for other in s)
+            if approx_len_of(self) + other_lens > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This set is too large")
+            super().update(*s)
+            self.__approx_len__ += other_lens
+
+        def add(self, element):
+            if approx_len_of(self) + 1 > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This set is too large")
+            super().add(element)
+            self.__approx_len__ += 1
+
+        def union(self, *s):
+            if approx_len_of(self) + sum(approx_len_of(other) for other in s) > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This set is too large")
+            return SafeSet(super().union(*s))
+
+        def pop(self):
+            retval = super().pop()
+            self.__approx_len__ -= 1
+            return retval
+
+        def remove(self, element):
+            super().remove(element)
+            self.__approx_len__ -= 1
+
+        def discard(self, element):
+            super().discard(element)
+            self.__approx_len__ -= 1
+
+        def clear(self):
+            super().clear()
+            self.__approx_len__ = 0
+
+    return SafeSet
+
+
+def safe_dict(config):
+    class SafeDict(dict):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.__approx_len__ = approx_len_of(self)
+
+        def update(self, other_dict=None, **kvs):
+            if other_dict is None:
+                other_dict = {}
+
+            other_lens = approx_len_of(other_dict) + approx_len_of(kvs)
+            if approx_len_of(self) + other_lens > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This dict is too large")
+
+            super().update(other_dict, **kvs)
+            self.__approx_len__ += other_lens
+
+        def __setitem__(self, key, value):
+            other_len = approx_len_of(value)
+            if approx_len_of(self) + other_len > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This dict is too large")
+            self.__approx_len__ += other_len
+            return super().__setitem__(key, value)
+
+        def pop(self, k):
+            retval = super().pop(k)
+            self.__approx_len__ -= 1
+            return retval
+
+        def __delitem__(self, key):
+            super().__delitem__(key)
+            self.__approx_len__ -= 1
+
+    return SafeDict
+
+
+def safe_str(config):
+    # noinspection PyShadowingBuiltins, PyPep8Naming
+    # naming it SafeStr would break typeof backward compatibility :(
+    class SafeStr(UserString):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def center(self, width, *args):
+            if width > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This str is too large")
+            return super().center(width, *args)
+
+        def encode(self, *_, **__):
+            _raise_in_context(FeatureNotAvailable, "This method is not allowed")
+
+        def expandtabs(self, tabsize=8):
+            if self.count('\t') * tabsize > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This str is too large")
+            return super().expandtabs(tabsize)
+
+        def format(self, *args, **kwargs):
+            _raise_in_context(FeatureNotAvailable, "This method is not allowed")
+
+        def format_map(self, mapping):
+            _raise_in_context(FeatureNotAvailable, "This method is not allowed")
+
+        def join(self, seq):
+            i = list(seq)
+            if len(i) * len(self) + approx_len_of(i) > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This str is too large")
+            return super().join(i)
+
+        def ljust(self, width, *args):
+            if width > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This str is too large")
+            return super().ljust(width, *args)
+
+        def replace(self, old, new, maxsplit=-1):
+            if maxsplit > 0:
+                n = maxsplit
+            else:
+                n = self.count(old)
+            if n * (len(new) - len(old)) + len(self) > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This str is too large")
+            return super().replace(old, new, maxsplit)
+
+        def rjust(self, width, *args):
+            if width > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This str is too large")
+            return super().rjust(width, *args)
+
+        def translate(self, table):
+            # this is kind of a disgusting way to check the worst-case length
+            # and is an overestimate by a multiplicative factor of len(table)
+            # but it is certainly an overestimate
+            if approx_len_of(table) * len(self) > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This str is too large")
+            return super().translate(table)
+
+        def zfill(self, width):
+            if width > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This str is too large")
+            return super().zfill(width)
+
+    return SafeStr

--- a/draconic/types.py
+++ b/draconic/types.py
@@ -242,9 +242,11 @@ def safe_str(config):
                 raise ValueError("Invalid format specifier")
 
             precision_len = 0
-            if w := match.group('width'):
+            w = match.group('width')
+            p = match.group('precision')
+            if w:
                 precision_len += int(w)
-            if p := match.group('precision'):
+            if p:
                 precision_len += int(p.lstrip('.'))
             if precision_len > config.max_const_len:
                 _raise_in_context(IterableTooLong, "This str is too large")
@@ -260,13 +262,15 @@ def safe_str(config):
 
             # validate that the template is safe (no massive widths/precisions)
             for match in PRINTF_TEMPLATE_RE.finditer(self.data):
-                if w := match.group('width'):
+                w = match.group('width')
+                if w:
                     if w == '*':
                         _raise_in_context(FeatureNotAvailable, "Star precision in printf-style formatting not allowed")
                     else:
                         new_len_bound += int(w)
 
-                if p := match.group('precision'):
+                p = match.group('precision')
+                if p:
                     if p == '.*':
                         _raise_in_context(FeatureNotAvailable, "Star precision in printf-style formatting not allowed")
                     else:

--- a/draconic/types.py
+++ b/draconic/types.py
@@ -171,7 +171,7 @@ def safe_dict(config):
 def safe_str(config):
     # noinspection PyShadowingBuiltins, PyPep8Naming
     # naming it SafeStr would break typeof backward compatibility :(
-    class SafeStr(UserString):
+    class str(UserString):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
@@ -232,4 +232,4 @@ def safe_str(config):
                 _raise_in_context(IterableTooLong, "This str is too large")
             return super().zfill(width)
 
-    return SafeStr
+    return str

--- a/tests/test_from_simpleeval.py
+++ b/tests/test_from_simpleeval.py
@@ -264,7 +264,7 @@ class TestTryingToBreakOut(DRYTest):
     def test_encode_bignums(self):
         # thanks gk
         if hasattr(1, 'from_bytes'):  # python3 only
-            with self.assertRaises(IterableTooLong):
+            with self.assertRaises(FeatureNotAvailable):
                 self.t('(1).from_bytes(b"123123123123123123123123"*999999, "big")', 0)
 
     def test_string_length(self):

--- a/tests/test_from_simpleeval.py
+++ b/tests/test_from_simpleeval.py
@@ -265,7 +265,7 @@ class TestTryingToBreakOut(DRYTest):
         # thanks gk
         if hasattr(1, 'from_bytes'):  # python3 only
             with self.assertRaises(IterableTooLong):
-                self.t('(1).from_bytes(("123123123123123123123123").encode()*999999, "big")', 0)
+                self.t('(1).from_bytes(b"123123123123123123123123"*999999, "big")', 0)
 
     def test_string_length(self):
         with self.assertRaises(IterableTooLong):
@@ -301,10 +301,7 @@ class TestTryingToBreakOut(DRYTest):
                 self.t("f'{\"foo\"*50000}'", 0)
 
     def test_bytes_array_test(self):
-        self.t("'20000000000000000000'.encode() * 5000",
-               '20000000000000000000'.encode() * 5000)
-
-        with self.assertRaises(IterableTooLong):
+        with self.assertRaises(FeatureNotAvailable):
             self.t("'123121323123131231223'.encode() * 5000", 20)
 
     def test_list_length_test(self):

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -141,6 +141,13 @@ def test_types_again(i, e):
     e("b = dict(((1, 1), (2, 2)))")
     assert type(i.names['a']) is type(i.names['b']) is i._dict
 
+    e("a = 'foobar'")
+    e("b = str(123)")
+    assert type(i.names['a']) is type(i.names['b']) is i._str
+
+    i.builtins['typeof'] = lambda o: type(o).__name__
+    assert e('typeof(a)') == 'str'
+
 
 def test_int_limits(e):
     max_int = (2 ** 31) - 1

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -258,7 +258,7 @@ def test_int_limits_not_floats(e):
     assert type(e("min_int // 0.5")) is float
 
 
-@pytest.mark.timeout(1)  # list mult should be fast, even if we do it a lot
+@pytest.mark.timeout(3)  # list mult should be fast, even if we do it a lot
 def test_list_mult_speed():
     config = DraconicConfig(max_loops=10000, max_const_len=10000)
     i = DraconicInterpreter(config=config)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -178,3 +178,5 @@ def test_getattr(i, e):
 
     assert e("l[0]") == 1
     assert e("l[-1]") == '3'
+
+    assert e("({'a': 1}).a") == 1  # dot notation getattr

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -107,3 +107,41 @@ def test_fstring_limits(i, e):
     assert e("f'{c:.10f}'") == '3.1400000000'
     with pytest.raises(IterableTooLong):
         e("f'{c:.1001f}'")
+
+
+def test_printf_templating_limites(i, e):
+    i.builtins.update({"a": 'foobar', "b": 42, "c": 3.14})
+    assert e("'%s %d %f' % (a, b, c)") == '%s %d %f' % ('foobar', 42, 3.14)
+
+    assert e("'%10s' % a") == '    foobar'
+    with pytest.raises(IterableTooLong):
+        e("'%1001s' % a")
+    with pytest.raises(IterableTooLong):
+        e("'%1001d' % b")
+
+    assert e("'%.10f' % b") == '42.0000000000'
+    with pytest.raises(IterableTooLong):
+        e("'%.1001f' % b")
+
+    assert e("'%.10f' % c") == '3.1400000000'
+    with pytest.raises(IterableTooLong):
+        e("'%.1001f' % c")
+
+    with pytest.raises(FeatureNotAvailable):
+        e("'%*f' % (a, b)")
+    with pytest.raises(FeatureNotAvailable):
+        e("'%.*f' % (a, b)")
+    with pytest.raises(FeatureNotAvailable):
+        e("'%*.*f' % (a, b, b)")
+
+
+def test_getattr(i, e):
+    """Check that our weird type shenanigans haven't borked anything when getattring w/ str key"""
+    i.builtins.update({"d": {"abc": "abc", 123: 123, ("1", 1): ("1", 1)},
+                       "l": [1, 2, "3"]})
+    assert e("d['abc']") == 'abc'
+    assert e("d[123]") == 123
+    assert e("d[('1', 1)]") == ("1", 1)
+
+    assert e("l[0]") == 1
+    assert e("l[-1]") == '3'

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -1,0 +1,93 @@
+import pytest
+
+from draconic import DraconicInterpreter
+from draconic.exceptions import *
+from draconic.helpers import DraconicConfig
+
+
+@pytest.fixture()
+def i():
+    # 1000-size iterables, don't limit us by loops, signed 32b int limit
+    config = DraconicConfig(max_loops=99999999, max_const_len=1000, max_int_size=32)
+    return DraconicInterpreter(config=config)
+
+
+def test_center(e):
+    assert e("'foo'.center(5)") == ' foo '
+    with pytest.raises(IterableTooLong):
+        e("'foo'.center(999999999999)")
+
+
+def test_encode(e):
+    with pytest.raises(FeatureNotAvailable):
+        e("'blargh'.encode()")
+
+    with pytest.raises(FeatureNotAvailable):
+        e("b'blargh'")
+
+
+def test_expandtabs(e):
+    assert e("'\tfoo'.expandtabs()") == '\tfoo'.expandtabs()
+    with pytest.raises(IterableTooLong):
+        e("'\tfoo'.expandtabs(99999999999)")
+    with pytest.raises(IterableTooLong):
+        e("('\t'*999).expandtabs(2)")
+
+
+def test_format(e):
+    with pytest.raises(FeatureNotAvailable):
+        e("'{}'.format(1)")
+
+
+def test_format_map(e):
+    with pytest.raises(FeatureNotAvailable):
+        e("'{a}'.format_map({'a': 1})")
+
+
+def test_join(e):
+    assert e("'foo'.join('bar')") == 'bfooafoor'
+    assert e("'foo'.join(['b', 'a', 'r'])") == 'bfooafoor'
+    with pytest.raises(AnnotatedException, match='expected str instance, int found'):
+        e("'foo'.join([1, 2, 3])")
+    with pytest.raises(IterableTooLong):
+        e("(' ' * 999).join(' ' * 999)")
+
+
+def test_ljust(e):
+    assert e("'foo'.ljust(5)") == "foo  "
+    with pytest.raises(IterableTooLong):
+        e("'foo'.ljust(1001)")
+
+
+def test_replace(e):
+    assert e("'foo'.replace('o', 'a')") == 'faa'
+    assert e("'foo'.replace('z', 'a'*999)") == 'foo'
+    assert e("'foo'.replace('f', 'a'*998)") == 'foo'.replace('f', 'a' * 998)
+    with pytest.raises(IterableTooLong):
+        e("'foo'.replace('o', 'a'*999)")
+    with pytest.raises(IterableTooLong):
+        e("'foo'.replace('f', 'a'*999)")
+
+
+def test_rjust(e):
+    assert e("'foo'.rjust(5)") == '  foo'
+    with pytest.raises(IterableTooLong):
+        e("'foo'.rjust(1001)")
+
+
+def test_translate(e):
+    assert e("'foo'.translate({102: 'ba', 111: 'na'})") == 'banana'
+    with pytest.raises(IterableTooLong):
+        e("'ff'.translate({102: 'a'*999})")
+
+
+def test_zfill(e):
+    assert e("'15'.zfill(5)") == '00015'
+    assert e("'-15'.zfill(5)") == '-0015'
+    with pytest.raises(IterableTooLong):
+        e("'foo'.zfill(1001)")
+    with pytest.raises(IterableTooLong):
+        e("'1'.zfill(1001)")
+    with pytest.raises(IterableTooLong):
+        e("'-1'.zfill(1001)")
+

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -91,3 +91,19 @@ def test_zfill(e):
     with pytest.raises(IterableTooLong):
         e("'-1'.zfill(1001)")
 
+
+def test_fstring_limits(i, e):
+    i.builtins.update({"a": 'foobar', "b": 42, "c": 3.14})
+    assert e("f'{a} {b} {c}'") == 'foobar 42 3.14'
+
+    assert e("f'{a:10}'") == 'foobar    '
+    with pytest.raises(IterableTooLong):
+        e("f'{a:1001}'")
+
+    assert e("f'{b:.10f}'") == '42.0000000000'
+    with pytest.raises(IterableTooLong):
+        e("f'{b:.1001f}'")
+
+    assert e("f'{c:.10f}'") == '3.1400000000'
+    with pytest.raises(IterableTooLong):
+        e("f'{c:.1001f}'")


### PR DESCRIPTION
### Summary
Adds a userstr type to allow overloading of `str` methods and better size checking. Pulls all the custom type stuff into its own file.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
    - Disallowed the usage of `str.encode()` and bytes literals
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
