### PR TITLE
Add default arg to safe_dict.pop()

### DIFF
--- a/draconic/types.py
+++ b/draconic/types.py
@@ -159,11 +159,11 @@ def safe_dict(config):
             self.__approx_len__ += other_len
             return super().__setitem__(key, value)
 
-        def pop(self, key, default=_sentinel):
+        def pop(self, k, default=_sentinel):
             if default is not _sentinel:
-                retval = super().pop(key, default)
+                retval = super().pop(k, default)
             else:
-                retval = super().pop(key)
+                retval = super().pop(k)
             self.__approx_len__ -= 1
             return retval
 

--- a/draconic/types.py
+++ b/draconic/types.py
@@ -9,6 +9,7 @@ __all__ = (
     'safe_list', 'safe_dict', 'safe_set', 'safe_str', 'approx_len_of'
 )
 
+_sentinel = object()
 
 # ---- size helper ----
 def approx_len_of(obj, visited=None):
@@ -158,8 +159,11 @@ def safe_dict(config):
             self.__approx_len__ += other_len
             return super().__setitem__(key, value)
 
-        def pop(self, k):
-            retval = super().pop(k)
+        def pop(self, key, default=_sentinel):
+            if default is not _sentinel:
+                retval = super().pop(key, default)
+            else:
+                retval = super().pop(key)
             self.__approx_len__ -= 1
             return retval
 

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -106,6 +106,26 @@ def test_that_it_still_works_right(i, e):
     assert e("d") == {1: 1, 2: 2}
     assert isinstance(i.names['d'], i._dict)
 
+    pop = e("d.pop(2)")
+    assert e("d") == {1: 1}
+    assert pop == 2
+    assert isinstance(i.names['d'], i._dict)
+
+    e("d.update({2: 2})")
+
+    pop = e("d.pop(2, 3)")
+    assert e("d") == {1: 1}
+    assert pop == 2
+    assert isinstance(i.names['d'], i._dict)
+
+    pop = e("d.pop(2, 3)")
+    assert e("d") == {1: 1}
+    assert pop == 3
+    assert isinstance(i.names['d'], i._dict)
+
+    with pytest.raises(AnnotatedException):
+        e("d.pop(2)")
+
 
 def test_types(i, e):
     # when we have a compound type as a builtin, users shouldn't be able to modify it directly...


### PR DESCRIPTION
### Summary
Adds a `default` arg to `safe_dict.pop()` to match normal Python `Dict.pop()`. I gave the 

Resolves https://github.com/avrae/avrae/issues/1575

The only part I was unsure of was not checking if the key was in the dict for changing the `__approx_len__`, but I figured it was approximate so I just didn't modify it.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
