### PR TITLE
chore: make safelists also lists

### DIFF
--- a/draconic/types.py
+++ b/draconic/types.py
@@ -51,7 +51,9 @@ def approx_len_of(obj, visited=None):
 # each function is a function that returns a class based on Draconic config
 # ... look, it works
 def safe_list(config):
-    class SafeList(UserList):  # extends UserList so that [x] * y returns a SafeList, not a list
+    # the additional subclass of list makes isinstance checks against list pass
+    # it's a little hacky, but it shouldn't have any side effects
+    class SafeList(UserList, list):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.__approx_len__ = approx_len_of(self)


### PR DESCRIPTION
### Summary
Makes `SafeList` also a subclass of builtin `list`, in order to make checks like `isinstance(SafeList(...), list)` pass. This is important for libraries like pydantic, which expect specific types for sequence fields (see https://github.com/samuelcolvin/pydantic/issues/1038).

This shouldn't have any side effects as `collections.UserList` overrides every `list` method, though it is kind of... weird.

It might be worth removing the `UserList` inheritance entirely and just subclassing `list` - I experimented with this and it didn't seem to cause any issues. The only additional change needed to accomplish this is 
```diff
# L91
- new.data = self.data * n
+ new[:] = super().__mul__(n)
```