### PR TITLE
feat: DraconicIntepreter.execute_module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def i():
 
 @pytest.fixture()
 def e(i):
+    """eval"""
     def inner(expr):
         return i.eval(expr)
 
@@ -46,10 +47,20 @@ def _ex_impl_func(i, expr):
 
 @pytest.fixture(params=[_ex_impl_bare, _ex_impl_func], ids=["bare", "wrapped_func"])
 def ex(i, request):
+    """execute"""
     impl = request.param
 
     def inner(expr):
         i.out__ = []
         return impl(i, textwrap.dedent(expr))
+
+    return inner
+
+
+@pytest.fixture()
+def exm(i):
+    """execute module"""
+    def inner(expr):
+        return i.execute_module(expr)
 
     return inner

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -232,23 +232,29 @@ def test_return_for(ex):
 
 
 # outside
-def test_break_outside(e, ex):
+def test_break_outside(e, ex, exm):
     with utils.raises(DraconicSyntaxError):
         ex("break")
 
     with utils.raises(DraconicSyntaxError):
         e("break")
 
+    with utils.raises(DraconicSyntaxError):
+        exm("break")
 
-def test_continue_outside(e, ex):
+
+def test_continue_outside(e, ex, exm):
     with utils.raises(DraconicSyntaxError):
         ex("continue")
 
     with utils.raises(DraconicSyntaxError):
         e("continue")
 
+    with utils.raises(DraconicSyntaxError):
+        exm("continue")
 
-def test_return_outside(e, ex):
+
+def test_return_outside(e, ex, exm):
     expr = """
     return 1
     return 2
@@ -256,3 +262,6 @@ def test_return_outside(e, ex):
     """
     assert ex(expr) == 1
     assert e("return 1") == 1
+
+    with utils.raises(DraconicSyntaxError):
+        exm("return 1")


### PR DESCRIPTION
### Summary
Adds a utility method, `DraconicInterperter.execute_module`, to better handle imports in Avrae v4.1.

This is similar to *execute* except:
- it doesn't allow bare returns (it raises a SyntaxError instead)
- it doesn't call preflight (so execution limits are preserved in imports)
- it saves the previously running expression (so tracebacks point to the correct expression)
- it sets the exception context (so tracebacks show what import an issue was in)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
