### PR TITLE
feat: function dunder-like attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,32 @@ SyntaxError: alternative patterns bind different names
 ...         print(one)
 1
 ```
+
+### Function Dunder Attributes
+
+As access to `__dunder__` attributes is not allowed in Draconic, the `function.__name__` and `function.__doc__` 
+attributes are exposed as `function.name` and `function.doc` instead.
+
+**Python**
+
+```pycon
+>>> def foo():
+...     """I am foo"""
+...     pass
+>>> print(foo.__name__)
+foo
+>>> print(foo.__doc__)
+I am foo
+```
+
+**Draconic**
+
+```pycon
+>>> def foo():
+...     """I am foo"""
+...     pass
+>>> print(foo.name)
+foo
+>>> print(foo.doc)
+I am foo
+```

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -460,3 +460,27 @@ def test_shadow_assignment(i, ex):
     """
     with utils.raises(DraconicValueError):
         ex(expr)
+
+
+def test_introspection(i, ex):
+    expr = """
+    def foo():
+        '''i am foo'''
+        pass
+        
+    def bar():
+        pass
+        
+    bletch = lambda: None
+    foo2 = foo
+    
+    for callable in (foo, bar, bletch, foo2):
+        print((callable.name, callable.doc))
+    """
+    ex(expr)
+    assert i.out__ == [
+        ("foo", "i am foo"),
+        ("bar", None),
+        ("<lambda>", None),
+        ("foo", "i am foo"),
+    ]


### PR DESCRIPTION
### Summary
Exposes attrs to mimic the purpose of `function.__name__` and `function.__doc__` in Python. Since dunder access is not allowed in Draconic these are exposes without the underscores.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
