### PR TITLE
Implement Starred arguments and keyword arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,31 @@ foo
 >>> print(foo.doc)
 I am foo
 ```
+
+### Starred Unpacking
+
+Assigning to a starred variable outside of a tuple or list in Python throws a `SyntaxError`, but is valid in Draconic
+
+**Python**
+
+```pycon
+>>> *a = [1, 2, 3]
+SyntaxError: starred assignment target must be in a list or tuple
+```
+
+**Draconic**
+
+```pycon
+>>> *a = [1, 2, 3]
+>>> a
+[1, 2, 3]
+```
+
+This has syntactical equivalents in Python:
+
+```pycon
+>>> *a, = [1, 2, 3]
+>>> [*b] = [1, 2, 3]
+>>> (*c,) = [1, 2, 3]
+>>> assert a == b == c == [1, 2, 3]
+```

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -730,18 +730,9 @@ class DraconicInterpreter(SimpleInterpreter):
                         values,
                         self._expr,
                     )
-                for t, v in zip(names.elts, values):
-                    if t is starred:
-                        break
-                    values.remove(v)
-                    self._assign_unpack(t, v)
 
-                for t, v in zip(reversed(names.elts), reversed(values)):
-                    if t is starred:
-                        break
-                    values.remove(v)
+                for t, v in zip_star(names.elts, values, star_index=names.elts.index(starred)):
                     self._assign_unpack(t, v)
-                self._assign_unpack(starred, values)
 
     def _assign_starred(self, name, value):
         self._assign_name(name.value, value)

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -645,7 +645,7 @@ class DraconicInterpreter(SimpleInterpreter):
                         if self._loops > self._config.max_loops:
                             raise IterableTooLong("Unwrapping generates too many elements", items, self._expr)
                         if check_len:
-                            total_len += sum([approx_len_of(retval) for val in retval]) + 1
+                            total_len += sum(approx_len_of(val) for val in retval) + 1
                             if total_len > self._config.max_const_len:
                                 raise IterableTooLong("Unwrapping generates too much", items, self._expr)
                         yield retval
@@ -654,7 +654,7 @@ class DraconicInterpreter(SimpleInterpreter):
             else:
                 retval = self._eval(key) if isinstance(key, ast.AST) else key, evalue
                 if check_len:
-                    total_len += sum([approx_len_of(retval) for val in retval]) + 1
+                    total_len += sum([approx_len_of(val) for val in retval]) + 1
                     if total_len > self._config.max_const_len:
                         raise IterableTooLong("Unwrapping generates too much", items, self._expr)
                 yield retval

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -610,9 +610,7 @@ class DraconicInterpreter(SimpleInterpreter):
             if type(node) is ast.Starred:
                 evalue = self._eval(node.value)
                 try:
-                    iterable = iter(evalue)
-                    sentinel = object()
-                    while (retval := next(iterable, sentinel)) is not sentinel:
+                    for retval in evalue:
                         self._loops += 1
                         if self._loops > self._config.max_loops:
                             raise IterableTooLong("Unwrapping generates too many elements", nodes, self._expr)
@@ -638,9 +636,7 @@ class DraconicInterpreter(SimpleInterpreter):
             evalue = self._eval(value)
             if key is None:
                 if isinstance(evalue, Mapping):
-                    iterable = iter(evalue.items())
-                    sentinel = object()
-                    while (retval := next(iterable, sentinel)) is not sentinel:
+                    for retval in evalue.items():
                         self._loops += 1
                         if self._loops > self._config.max_loops:
                             raise IterableTooLong("Unwrapping generates too many elements", items, self._expr)

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -206,6 +206,17 @@ class TestCompoundAssignments:
         assert e("a") == 1
         assert e("b") == [2, 3, 4]
 
+        e("a, (b, *c, (d, *e, f), g), *h, i = (1, (2, 3, 4, (5, 6, 7, 8), 9), 10, 11, 12)")
+        assert e("a") == 1
+        assert e("b") == 2
+        assert e("c") == [3, 4]
+        assert e("d") == 5
+        assert e("e") == [6, 7]
+        assert e("f") == 8
+        assert e("g") == 9
+        assert e("h") == [10, 11]
+        assert e("i") == 12
+
     def test_compound_assignments(self, e):
         e("a = [1, 2, 3]")
         e('b = {"foo": "bar"}')

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -65,6 +65,13 @@ def test_list(i, e):
     with utils.raises(IterableTooLong):
         e("[*long, *long]")
 
+    # we should be able to unpack at the limit
+    e("[*long]")
+
+    # functions shouldn't be limited
+    i.builtins["max"] = max
+    e("max(*long, *long)")
+
     # we should always be operating using safe lists
     i.builtins["reallist"] = [1, 2, 3]
     e("my_list = [1, 2, 3]")
@@ -135,6 +142,9 @@ def test_set(i, e):
     with utils.raises(IterableTooLong):
         e("{*longer}")
 
+    # we should be able to unpack at the limit
+    e("{*long}")
+
     # we should always be operating using safe sets
     i.builtins["realset"] = {1, 2, 3}
     e("my_set = {3, 4, 5}")
@@ -175,6 +185,9 @@ def test_dict(i, e):
 
     with utils.raises(IterableTooLong):
         e("{**long, **long2}")
+
+    # we should be able to unpack at the limit
+    e("{**long}")
 
 
 def test_that_it_still_works_right(i, e):

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -26,10 +26,6 @@ def test_creating(i, e):
     with utils.raises(IterableTooLong):
         e(f"'{really_long_str}'")
 
-    # lists
-    with utils.raises(FeatureNotAvailable):  # we don't allow this
-        e(f"[*long, *long]")
-
 
 def test_f_string(i, e):
     really_long_str = "foo" * 1000
@@ -62,6 +58,12 @@ def test_list(i, e):
 
     with utils.raises(IterableTooLong):
         e("long.extend(long)")
+
+    with utils.raises(IterableTooLong):
+        e("[1, *long]")
+
+    with utils.raises(IterableTooLong):
+        e("[*long, *long]")
 
     # we should always be operating using safe lists
     i.builtins["reallist"] = [1, 2, 3]
@@ -127,6 +129,12 @@ def test_set(i, e):
     with utils.raises(IterableTooLong):
         e("long.symmetric_difference_update(long2)")
 
+    with utils.raises(IterableTooLong):
+        e("{*long, 1000}")
+
+    with utils.raises(IterableTooLong):
+        e("{*longer}")
+
     # we should always be operating using safe sets
     i.builtins["realset"] = {1, 2, 3}
     e("my_set = {3, 4, 5}")
@@ -164,6 +172,9 @@ def test_dict(i, e):
 
     with utils.raises(IterableTooLong):
         e("toolong2 = dict((f'{i:03}', 'a') for i in range(200, 343))")
+
+    with utils.raises(IterableTooLong):
+        e("{**long, **long2}")
 
 
 def test_that_it_still_works_right(i, e):


### PR DESCRIPTION
### Summary
Implements the Starred AST node, as well as the keyword-equivalent, for usage in functions, lists, dicts, etc.

This pull request is being opened for commentary on the implementation, and to help figure out how to implement tests.

As it stands, it does not properly raise IterableTooLong when trying to construct lists/dicts of large size using stars, and is missing the relevant tests, but is otherwise functional.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
