### PR TITLE
Add support for try/except

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,33 @@ foo
 >>> print(foo.doc)
 I am foo
 ```
+
+### Try/Except
+
+As Draconic currently has no user-defined class implementation, it is impossible to provide a type by name to an 
+`except` clause. Instead, Draconic requires `except` clause types to be a string literal or tuple of string literals.
+These are matched against the name of the exception, with no subclass checking.
+
+**Python**
+
+```pycon
+>>> try:
+...     1/0
+... except Exception:
+...     print("I catch all exceptions!")
+... except ZeroDivisionError:
+...     print("You divided by zero!")
+I catch all exceptions!
+```
+
+**Draconic**
+
+```pycon
+>>> try:
+...     1/0
+... except "Exception":
+...     print("I catch all exceptions!")
+... except "ZeroDivisionError":
+...     print("You divided by zero!")
+You divided by zero!
+```

--- a/tests/test_try_except.py
+++ b/tests/test_try_except.py
@@ -308,3 +308,27 @@ def test_try_except_flow_order(ex):
         return 3
     """
     assert ex(expr) == 3
+
+    expr = """
+    try:
+        pass
+    except:
+        pass
+    else:
+        return 2
+    finally:
+        pass
+    """
+    assert ex(expr) == 2
+
+    expr = """
+    try:
+        pass
+    except:
+        pass
+    else:
+        return 2
+    finally:
+        return 3
+    """
+    assert ex(expr) == 3

--- a/tests/test_try_except.py
+++ b/tests/test_try_except.py
@@ -1,0 +1,183 @@
+from draconic.exceptions import *
+from . import utils
+
+
+def test_try_except(i, ex):
+    expr = """
+    try:
+        1/0
+    except "Exception":
+        return "I catch all exceptions!"
+    except "ZeroDivisionError":
+        return "You divided by zero!"
+    """
+    assert ex(expr) == "You divided by zero!"
+
+    expr = """
+    try:
+        1/0
+    except:
+        return "I catch all exceptions!"
+    except "ZeroDivisionError":
+        return "You divided by zero!"
+    """
+    assert ex(expr) == "I catch all exceptions!"
+
+    expr = """
+    for x in ("foo", "None", "10e7", "10", "11"):
+        try:
+            print(int(x))
+            break
+        except "ValueError":
+            print("NaN")
+    """
+    ex(expr)
+    assert i.out__ == ["NaN", "NaN", "NaN", 10]
+
+    expr = """
+        for x in ("None", "10e7", "10", "11"):
+            try:
+                print(int(x))
+                break
+            except ("ValueError", "TypeError"):
+                print("NaN")
+        """
+    ex(expr)
+    assert i.out__ == ["NaN", "NaN", 10]
+
+    expr = """
+    def this_fails():
+        x = 1/0
+    
+    try:
+        this_fails()
+    except "ZeroDivisionError":
+        return "You divided by zero!"
+    """
+    assert ex(expr) == "You divided by zero!"
+
+
+def test_except_as_not_allowed(ex):
+    expr = """
+    try:
+        1/0
+    except "ZeroDivisionError" as e:
+        print(e)
+    """
+    with utils.raises(FeatureNotAvailable):
+        ex(expr)
+
+
+def test_try_else(i, ex):
+    expr = """
+    for divisor in (1, 0, 3, 0):
+        try:
+            print(1/divisor)
+        except "ZeroDivisionError":
+            print(">:c")
+        else:
+            print(":>")
+    """
+    ex(expr)
+    assert i.out__ == [1, ":>", ">:c", 1 / 3, ":>", ">:c"]
+
+
+def test_try_finally(i, ex):
+    expr = """
+    def divide(x, y):
+        try:
+            result = x / y
+        except "ZeroDivisionError":
+            print("division by zero!")
+        else:
+            print(f"result is {result}")
+        finally:
+            print("executing finally clause")
+    
+    divide(2, 1)
+    divide(2, 0)
+    divide("2", "1")
+    """
+    with utils.raises(TypeError):
+        ex(expr)
+    assert i.out__ == [
+        "result is 2.0",
+        "executing finally clause",
+        "division by zero!",
+        "executing finally clause",
+        "executing finally clause",
+    ]
+
+    expr = """
+    try:
+        return True
+    finally:
+        return False
+    """
+    assert ex(expr) is False
+
+
+def test_excepting_limits(i, ex):
+    with utils.temp_limits(
+        i,
+        max_const_len=10,
+        max_loops=10,
+        max_statements=15,
+        max_power_base=10,
+        max_power=10,
+        max_int_size=3,
+        max_recursion_depth=3,
+    ):
+        with utils.raises(NumberTooHigh):
+            ex(
+                """
+                try:
+                    return 7 + 7
+                except "NumberTooHigh":
+                    pass
+                """
+            )
+
+        with utils.raises(IterableTooLong):
+            ex(
+                """
+                try:
+                    return "aaaaaaaaaaa"
+                except "IterableTooLong":
+                    pass
+                """
+            )
+
+        with utils.raises(TooManyStatements):
+            ex(
+                """
+                try:
+                    for _ in "123456789": pass
+                    for _ in "123456789": pass
+                except "TooManyStatements":
+                    pass
+                """
+            )
+
+        with utils.raises(TooMuchRecursion):
+            ex(
+                """
+                def foo():
+                    foo()
+                
+                try:
+                    foo()
+                except "TooMuchRecursion":
+                    pass
+                """
+            )
+
+        with utils.raises(NumberTooHigh):
+            ex(
+                """
+                try:
+                    return 7 + 7
+                except:
+                    pass
+                """
+            )

--- a/tests/test_try_except.py
+++ b/tests/test_try_except.py
@@ -181,3 +181,130 @@ def test_excepting_limits(i, ex):
                     pass
                 """
             )
+
+
+def test_incorrect_except_types(ex):
+    expr = """
+    try:
+        1/0
+    except None:
+        pass
+    """
+    with utils.raises(FeatureNotAvailable):
+        ex(expr)
+
+    expr = """
+    try:
+        1/0
+    except ["a", "b"]:
+        pass
+    """
+    with utils.raises(FeatureNotAvailable):
+        ex(expr)
+
+    expr = """
+    try:
+        1/0
+    except ("Exception", None):
+        pass
+    """
+    with utils.raises(FeatureNotAvailable):
+        ex(expr)
+
+
+def test_try_except_flow_order(ex):
+    expr = """
+    try:
+        return 0
+    except:
+        return 1
+    else:
+        return 2
+    finally:
+        return 3
+    """
+    assert ex(expr) == 3
+
+    expr = """
+    try:
+        return 0
+    except:
+        return 1
+    else:
+        return 2
+    """
+    assert ex(expr) == 0
+
+    expr = """
+    try:
+        return 0
+    except:
+        return 1
+    finally:
+        return 3
+    """
+    assert ex(expr) == 3
+
+    expr = """
+    try:
+        return 0
+    except:
+        return 1
+    """
+    assert ex(expr) == 0
+
+    expr = """
+    try:
+        return 0
+    finally:
+        return 3
+    """
+    assert ex(expr) == 3
+
+    expr = """
+    try:
+        return 1/0
+    except:
+        return 1
+    else:
+        return 2
+    finally:
+        return 3
+    """
+    assert ex(expr) == 3
+
+    expr = """
+    try:
+        return 1/0
+    except:
+        return 1
+    else:
+        return 2
+    """
+    assert ex(expr) == 1
+
+    expr = """
+    try:
+        return 1/0
+    except:
+        return 1
+    finally:
+        return 3
+    """
+    assert ex(expr) == 3
+
+    expr = """
+    try:
+        return 1/0
+    except:
+        return 1
+    """
+    assert ex(expr) == 1
+
+    expr = """
+    try:
+        return 1/0
+    finally:
+        return 3
+    """
+    assert ex(expr) == 3


### PR DESCRIPTION
### Summary
This PR adds support for try/except clauses (including `else` and `finally`) to Draconic, requiring caught exception types to be passed as a string or tuple of strings, and only allowing exact matches against exception names (i.e. no subclassing checks).

Passing exact exception types as a string instead of simply checking against the name of an `ast.Name` node technically extends the Python behaviour while allowing room to implement Python-spec exception type matching later down the line without breaking changes.

In order to maintain interpreter safety, `LimitException`s cannot be caught and `WrappedException`s are unwrapped before it handles `except` clauses.

### TODOs before merging:

- [x] document try/excepts in avrae/avrae

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
