### PR TITLE
fix(comp): do not allow comp to bypass limit

### DIFF
--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -587,7 +587,7 @@ class DraconicInterpreter(SimpleInterpreter):
                     else:
                         # emit values
                         value = do_value(comprehension_node)
-                        total_len += sum([approx_len_of(val) for val in value]) if is_dictcomp else approx_len_of(value)
+                        total_len += sum(approx_len_of(val) for val in value) if is_dictcomp else approx_len_of(value)
                         total_len += 1
                         if total_len > self._config.max_const_len:
                             raise IterableTooLong("Comprehension generates too much", comprehension_node, self._expr)

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -70,6 +70,13 @@ def test_list(i, e):
     assert isinstance(e("reallist + my_list"), i._list)
     e("my_list.extend(reallist)")
     assert isinstance(e("my_list"), i._list)
+    
+    # check that you can't bypass cont limits with comprehension
+    i.builtins["range"] = range
+    e("[f'{x:03}' for x in range(250)]")
+    
+    with utils.raises(IterableTooLong):
+        e("[f'{x:03}' for x in range(251)]")
 
 
 def test_set(i, e):
@@ -157,12 +164,6 @@ def test_dict(i, e):
         
     with utils.raises(IterableTooLong):
         e("toolong2 = dict((f'{i:03}', 'a') for i in range(200, 343))")
-            
-def test_comprehension(i, e):
-    # check that you can't bypass cont limits with comprehension
-    with utils.raises(IterableTooLong):
-        i.builtins["range"] = range
-        e("[f'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{x}' for x in range(1000)]")
 
 def test_that_it_still_works_right(i, e):
     e("l = [1, 2]")

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -70,11 +70,11 @@ def test_list(i, e):
     assert isinstance(e("reallist + my_list"), i._list)
     e("my_list.extend(reallist)")
     assert isinstance(e("my_list"), i._list)
-    
+
     # check that you can't bypass cont limits with comprehension
     i.builtins["range"] = range
     e("[f'{x:03}' for x in range(250)]")
-    
+
     with utils.raises(IterableTooLong):
         e("[f'{x:03}' for x in range(251)]")
 
@@ -158,12 +158,13 @@ def test_dict(i, e):
 
         with utils.raises(IterableTooLong):
             e("long_copy |= long2")
-            
+
     with utils.raises(IterableTooLong):
         e("toolong = {f'{i:03}': 'a' for i in range(201)}")
-        
+
     with utils.raises(IterableTooLong):
         e("toolong2 = dict((f'{i:03}', 'a') for i in range(200, 343))")
+
 
 def test_that_it_still_works_right(i, e):
     e("l = [1, 2]")

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -132,8 +132,8 @@ def test_set(i, e):
 
 def test_dict(i, e):
     i.builtins["range"] = range
-    e("long = dict((i, i) for i in range(1000))")
-    e("long2 = {i: i for i in range(1000, 2000)}")
+    e("long = {f'{i:03}': 'a' for i in range(200)}")
+    e("long2 = dict((f'{i:03}', 'a') for i in range(200, 342))")
     e("long_copy = long.copy()")
 
     with utils.raises(IterableTooLong):
@@ -151,7 +151,12 @@ def test_dict(i, e):
 
         with utils.raises(IterableTooLong):
             e("long_copy |= long2")
-
+            
+def test_comprehension(i, e):
+    # check that you can't bypass cont limits with comprehension
+    with utils.raises(IterableTooLong):
+        i.builtins["range"] = range
+        e("[f'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{x}' for x in range(1000)]")
 
 def test_that_it_still_works_right(i, e):
     e("l = [1, 2]")

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -152,6 +152,12 @@ def test_dict(i, e):
         with utils.raises(IterableTooLong):
             e("long_copy |= long2")
             
+    with utils.raises(IterableTooLong):
+        e("toolong = {f'{i:03}': 'a' for i in range(201)}")
+        
+    with utils.raises(IterableTooLong):
+        e("toolong2 = dict((f'{i:03}', 'a') for i in range(200, 343))")
+            
 def test_comprehension(i, e):
     # check that you can't bypass cont limits with comprehension
     with utils.raises(IterableTooLong):


### PR DESCRIPTION
### Summary
Fixes the do_generator function so that it tracks the approximate length while doing comprehensions, not allowing them to bypass the configured limit. Had to edit the dict_test as they were using values that were larger than the constant limit.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
