### PR TITLE
nit: add thousands separaters

### DIFF
--- a/draconic/helpers.py
+++ b/draconic/helpers.py
@@ -17,11 +17,11 @@ class DraconicConfig:
 
     def __init__(
         self,
-        max_const_len=200000,
-        max_loops=10000,
-        max_statements=100000,
-        max_power_base=1000000,
-        max_power=1000,
+        max_const_len=200_000,
+        max_loops=10_000,
+        max_statements=100_000,
+        max_power_base=1_000_000,
+        max_power=1_000,
         disallow_prefixes=None,
         disallow_methods=None,
         default_names=None,


### PR DESCRIPTION
### Summary
Adds thousands separators to the DraconicConfig default constants

Slight readability increase, zero functionality impact.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
