### PR TITLE
fix: *args and **kwargs in function defs can no longer bypass size limits

### DIFF
--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -934,9 +934,13 @@ class DraconicInterpreter(SimpleInterpreter):
                 self._names[kwargonly.arg] = self._eval(arguments.kw_defaults[k_i])
         # *args
         if arguments.vararg is not None:
+            if approx_len_of(args[args_i:]) > self._config.max_const_len:
+                raise IterableTooLong(f"**{arguments.vararg.arg} would be too large")
             self._names[arguments.vararg.arg] = tuple(args[args_i:])
         # **kwargs
         if arguments.kwarg is not None:
+            if approx_len_of(kwargs) > self._config.max_const_len:
+                raise IterableTooLong(f"**{arguments.kwarg.arg} would be too large")
             self._names[arguments.kwarg.arg] = kwargs
         elif kwargs:  # and arguments.kwarg is None (implicit)
             raise TypeError(f"{__functiondef._name}() got unexpected keyword arguments: {tuple(kwargs.keys())}")

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -935,12 +935,12 @@ class DraconicInterpreter(SimpleInterpreter):
         # *args
         if arguments.vararg is not None:
             if approx_len_of(args[args_i:]) > self._config.max_const_len:
-                raise IterableTooLong(f"**{arguments.vararg.arg} would be too large")
+                _raise_in_context(IterableTooLong, f"**{arguments.vararg.arg} would be too large")
             self._names[arguments.vararg.arg] = tuple(args[args_i:])
         # **kwargs
         if arguments.kwarg is not None:
             if approx_len_of(kwargs) > self._config.max_const_len:
-                raise IterableTooLong(f"**{arguments.kwarg.arg} would be too large")
+                _raise_in_context(IterableTooLong, f"**{arguments.kwarg.arg} would be too large")
             self._names[arguments.kwarg.arg] = kwargs
         elif kwargs:  # and arguments.kwarg is None (implicit)
             raise TypeError(f"{__functiondef._name}() got unexpected keyword arguments: {tuple(kwargs.keys())}")

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -935,7 +935,7 @@ class DraconicInterpreter(SimpleInterpreter):
         # *args
         if arguments.vararg is not None:
             if approx_len_of(args[args_i:]) > self._config.max_const_len:
-                _raise_in_context(IterableTooLong, f"**{arguments.vararg.arg} would be too large")
+                _raise_in_context(IterableTooLong, f"*{arguments.vararg.arg} would be too large")
             self._names[arguments.vararg.arg] = tuple(args[args_i:])
         # **kwargs
         if arguments.kwarg is not None:

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -393,22 +393,27 @@ def test_stmt_limit(i):
             i.execute(expr)
 
 
-def test_func_limit(ex):
+def test_func_limit(i, e):
     # functions should not be able to escape
-    okay_expr = """
-    long = "f"*999
-    def test_args(*args):
-        return args
-    test_args(long)
-    """
+    e("""long = "f"*999""")
+    e(
+        """
+def test(*args):
+    return args
+"""
+    )
 
-    bad_expr = """
-    long = "f"*999
-    def test_args(*args):
-        return args
-    test_args(long, long)
-    """
-
-    ex(okay_expr)
+    e("test(long)")
     with utils.raises(IterableTooLong):
-        ex(bad_expr)
+        e("test(long, long)")
+
+    # should also apply to lambda functions
+    e("""test2 = lambda *args: args""")
+    e("test(long)")
+    with utils.raises(IterableTooLong):
+        e("test(long, long)")
+
+    i.builtins["max"] = max
+
+    # should not apply to builtins
+    e("max(long, long)")

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -391,3 +391,24 @@ def test_stmt_limit(i):
     with temp_limits(i, max_statements=10):
         with utils.raises(TooManyStatements):
             i.execute(expr)
+
+
+def test_func_limit(ex):
+    # functions should not be able to escape
+    okay_expr = """
+    long = "f"*999
+    def test_args(*args):
+        return args
+    test_args(long)
+    """
+
+    bad_expr = """
+    long = "f"*999
+    def test_args(*args):
+        return args
+    test_args(long, long)
+    """
+
+    ex(okay_expr)
+    with utils.raises(IterableTooLong):
+        ex(bad_expr)


### PR DESCRIPTION
### Summary
Fixes user defined functions being able to create variables that bypass size limits by passing in multiple large args to a function that takes `*args` or `**kwargs`
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
