### PR TITLE
getattr weirdness is now contained

### DIFF
--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -215,13 +215,7 @@ class SimpleInterpreter(OperatorMixin):
         except (AttributeError, TypeError):
             pass
 
-        # Try and look for [x] if .x doesn't work
-        try:
-            return node_evaluated[node.attr]
-        except (KeyError, TypeError):
-            pass
-
-        # If it is neither, raise an exception
+        # If it is not present, raise an exception
         raise NotDefined(f"'{type(node_evaluated).__name__}' object has no attribute {node.attr}", node, self._expr)
 
     def _eval_index(self, node):

--- a/draconic/interpreter.py
+++ b/draconic/interpreter.py
@@ -213,10 +213,8 @@ class SimpleInterpreter(OperatorMixin):
         try:
             return getattr(node_evaluated, node.attr)
         except (AttributeError, TypeError):
-            pass
-
-        # If it is not present, raise an exception
-        raise NotDefined(f"'{type(node_evaluated).__name__}' object has no attribute {node.attr}", node, self._expr)
+            # If it is not present, raise an exception
+            raise NotDefined(f"'{type(node_evaluated).__name__}' object has no attribute {node.attr}", node, self._expr)
 
     def _eval_index(self, node):
         return self._eval(node.value)

--- a/draconic/types.py
+++ b/draconic/types.py
@@ -205,6 +205,12 @@ def safe_dict(config):
             super().__delitem__(key)
             self.__approx_len__ -= 1
 
+        def __getattr__(self, attr):
+            try:
+                return self[attr]
+            except KeyError:
+                raise AttributeError
+
         if PY_39:
 
             def __or__(self, other):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -126,6 +126,10 @@ class TestDict:
         e("a.update(a='foo')")
         assert e("a") == {1: 1, 2: 2, 3: 3, "a": "foo"}
 
+    def test_access(self, i, e):
+        e("a = {'a': 1, 'b': 2}")
+        assert e("a.a") == e("a['a']")
+
     if PY_39:
 
         def test_union_op(self, e):


### PR DESCRIPTION
### Summary
The interpreter silently getting items when you asked for an attribute was sorta weird, so now it's an inherent part of SafeDict's getattr method instead. This quirk was undocumented already, so I'm not really sure where it should be documented now.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
