### PR TITLE
fix: unwrap UserStrings in SafeStr constructor

### DIFF
--- a/draconic/types.py
+++ b/draconic/types.py
@@ -223,8 +223,13 @@ def safe_str(config):
     # noinspection PyShadowingBuiltins, PyPep8Naming
     # naming it SafeStr would break typeof backward compatibility :(
     class str(UserString, _real_str):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
+        def __init__(self, seq):
+            if isinstance(seq, UserString):
+                self.data = seq.data[:]
+            elif isinstance(seq, _real_str):
+                self.data = seq
+            else:
+                self.data = _real_str(seq)
 
         def center(self, width, *args):
             if width > config.max_const_len:

--- a/draconic/types.py
+++ b/draconic/types.py
@@ -262,6 +262,18 @@ def safe_str(config):
                 _raise_in_context(IterableTooLong, "This str is too large")
             return super().ljust(width, *args)
 
+        @staticmethod
+        def maketrans(*args):
+            if len(args) == 1 and isinstance(args[0], dict):
+                # str.maketrans expects a dict object and nothing else
+                # So SafeDict needs to be cast to dict for the method to work
+                return _real_str.maketrans(dict(args[0]))
+
+            if sum(approx_len_of(a) for a in args) > config.max_const_len:
+                _raise_in_context(IterableTooLong, "This dict is too large")
+
+            return _real_str.maketrans(*args)
+
         def replace(self, old, new, maxsplit=-1):
             if maxsplit > 0:
                 n = maxsplit

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -194,3 +194,11 @@ def test_strip(e):
 
 def test_internal_data(e):
     assert type(e("'a'").data) is type(e("str('a')").data)
+
+
+def test_maketrans(e):
+    assert e("str.maketrans({'a': 'b'})") == {97: "b"}
+    assert e("str.maketrans('a', 'b')") == {97: 98}
+    assert e("str.maketrans('a', 'b', 'c')") == {97: 98, 99: None}
+    with utils.raises(TypeError, match="if you give only one argument to maketrans it must be a dict"):
+        assert e("str.maketrans('a')")

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -190,3 +190,7 @@ def test_strip(e):
     assert e("' aaa  '.strip()") == "aaa"
     assert e("'foobar'.lstrip('f')") == "oobar"
     assert e("'foobar'.rstrip('ra')") == "foob"
+
+
+def test_internal_data(e):
+    assert type(e("'a'").data) is type(e("str('a')").data)


### PR DESCRIPTION
Supersedes #26 
Resolves AVR-955 (Not open on GitHub)

### Summary
Previously, calls to `str(SafeStr)` would keep a `SafeStr` as the internal data, when the internal data should always be a normal string.
The `UserString` constructor was intended to do this wrapping already, however since `SafeStr` also inherited from `str`, it bypassed this unwrapping.
The fix just pulls the unwrapping out from the `UserString` constructor into the `SafeStr` constructor.

Internet Cookie goes to Zhu for figuring this out at half-past 1AM.

Additionally, fixes `str.maketrans` by unwrapping a `SafeDict` when called with a single argument, since `str.maketrans` only accepts dicts, not mapping objects.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
