### PR TITLE
fix(types): safer immut types & iter handling

### DIFF
--- a/draconic/types.py
+++ b/draconic/types.py
@@ -29,17 +29,19 @@ def approx_len_of(obj, visited=None):
         obj = obj.items()
 
     try:
-        for child in iter(obj):
+        obj_iter = iter(obj)
+    except TypeError:  # object is not iterable
+        pass
+    else:
+        for child in obj_iter:
             if child in visited:
                 continue
             size += approx_len_of(child, visited)
             visited.append(child)
-    except TypeError:  # object is not iterable
-        pass
 
     try:
         setattr(obj, "__approx_len__", size)
-    except AttributeError:
+    except (AttributeError, TypeError):
         pass
 
     return size


### PR DESCRIPTION
### Summary
Fixes immutable types being unusable when in iterables because they were getting size checked, and also made sure to not skip size checks on iterables if a TypeError is raised while checking the size of the contents, instead only the iter(obj) line is checked by the try-except, using an else instead.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
